### PR TITLE
add cronie/crontab for scheduled jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,6 @@ USER root
 RUN yum update -y; yum clean all
 
 # Install php-xmlrpc module from RHSCL repo 
-RUN yum-config-manager --enable rhel-server-rhscl-7-rpms; yum install -y rh-php72-php-xmlrpc; yum clean all
+RUN yum-config-manager --enable rhel-server-rhscl-7-rpms; yum install -y rh-php72-php-xmlrpc cronie; yum clean all
 
 USER 1001


### PR DESCRIPTION
This is to add the ability for moodle (which uses this image) to execute a scheduled job in-container. There's a remote version of the job within moodle (ie: callable via `curl`) but it's being deprecated at some point so this is probably a more sustainable approach.